### PR TITLE
ZIP.ExtractArchive - Bug fix

### DIFF
--- a/Frends.Zip.ExtractArchive/CHANGELOG.md
+++ b/Frends.Zip.ExtractArchive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2024-10-22
+### Fixed
+- Fixed issue with rename option writing the extracted files to wrong directory.
+### Added
+- Added DeletetZipFileAfterExtract option to enable the deletion of the source file.
+
 ## [1.0.3] - 2022-02-23
 ### Changed
 - Added documentation link to task description

--- a/Frends.Zip.ExtractArchive/CHANGELOG.md
+++ b/Frends.Zip.ExtractArchive/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 - Fixed issue with rename option writing the extracted files to wrong directory.
 ### Added
-- Added DeletetZipFileAfterExtract option to enable the deletion of the source file.
+- DeleteZipFileAfterExtract option to enable the deletion of the source file.
 
 ## [1.0.3] - 2022-02-23
 ### Changed

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.Tests/UnitTests.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.Tests/UnitTests.cs
@@ -11,7 +11,7 @@ namespace Frends.Zip.ExtractArchive.Tests;
 [TestFixture]
 public class UnZipTests
 {
-    private readonly string[] fileNames = 
+    private readonly string[] fileNames =
     {
         "logo1.png",
         "logo2.png",
@@ -153,7 +153,7 @@ public class UnZipTests
         Assert.True(lines.Contains("First file") && lines.Contains("Second file") && lines.Contains("Third file"));
 
         sp.SourceFile = Path.Combine(inputPath, "testzip2.zip");
-        output = Zip.ExtractArchive(sp,  opt, new CancellationToken());
+        output = Zip.ExtractArchive(sp, opt, new CancellationToken());
         var lines2 = Directory.EnumerateFiles(sp.DestinationDirectory, "*", SearchOption.AllDirectories).Select(x => File.ReadLines(x).First()).ToList();
         Assert.False(lines2.Contains("First file") && lines2.Contains("Second file") && lines2.Contains("Third file"));
         Assert.True(lines2.Contains("Fourth file") && lines2.Contains("Fifth file") && lines2.Contains("Sixth file"));
@@ -170,9 +170,9 @@ public class UnZipTests
         sp.DestinationDirectory = outputPath;
 
         // Extract files to TestOut, so that there are existing files.
-        Zip.ExtractArchive(sp,  opt, new CancellationToken());
+        Zip.ExtractArchive(sp, opt, new CancellationToken());
 
-        var output = Zip.ExtractArchive(sp,  opt, new CancellationToken());
+        var output = Zip.ExtractArchive(sp, opt, new CancellationToken());
 
         // Create filenames to test against.
         outputFiles = new List<string>();
@@ -189,7 +189,7 @@ public class UnZipTests
     {
         File.Copy(Path.Combine(inputPath, "HiQLogos.zip"), Path.Combine(inputPath, "HiQLogos(1).zip"));
         sp.SourceFile = Path.Combine(inputPath, "HiQLogos(1).zip");
-        opt.DeletetZipFileAfterExtract = true;
+        opt.DeleteZipFileAfterExtract = true;
 
         opt.DestinationFileExistsAction = UnzipFileExistAction.Error;
         opt.CreateDestinationDirectory = true;

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/Enums.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/Enums.cs
@@ -3,11 +3,11 @@
 /// <summary>
 /// Unzip file exist actions.
 /// </summary>
-public enum UnzipFileExistAction 
+public enum UnzipFileExistAction
 {
 #pragma warning disable CS1591 // self explanatory.
     Error,
-    Overwrite, 
+    Overwrite,
     Rename
 #pragma warning restore CS1591 // self explanatory.
 };

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipInputProperties.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipInputProperties.cs
@@ -12,7 +12,7 @@ public class UnzipInputProperties
     /// Full path to the source file.
     /// </summary>
     /// <example>c:\example\file.zip</example>
-    [DisplayFormat(DataFormatString="Text")]
+    [DisplayFormat(DataFormatString = "Text")]
     public string SourceFile { get; set; }
 
     /// <summary>
@@ -26,6 +26,6 @@ public class UnzipInputProperties
     /// Destination directory.
     /// </summary>
     /// <example>C:\example</example>
-    [DisplayFormat(DataFormatString ="Text")]
+    [DisplayFormat(DataFormatString = "Text")]
     public string DestinationDirectory { get; set; }
 }

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipOptions.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipOptions.cs
@@ -22,9 +22,10 @@ public class UnzipOptions
     public bool CreateDestinationDirectory { get; set; }
 
     /// <summary>
-    /// Deletes the zip file after extraction.
+    /// If set to true, the source ZIP file will be deleted after successful extraction.
     /// </summary>
     /// <example>true</example>
     [DefaultValue(false)]
-    public bool DeletetZipFileAfterExtract { get; set; }
+    [DisplayName("Delete ZIP file after extraction")]
+    public bool DeleteZipFileAfterExtract { get; set; }
 }

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipOptions.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Definitions/UnzipOptions.cs
@@ -20,4 +20,11 @@ public class UnzipOptions
     [DefaultValue(false)]
     [DisplayName(@"Create destination directory")]
     public bool CreateDestinationDirectory { get; set; }
+
+    /// <summary>
+    /// Deletes the zip file after extraction.
+    /// </summary>
+    /// <example>true</example>
+    [DefaultValue(false)]
+    public bool DeletetZipFileAfterExtract { get; set; }
 }

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Extensions.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Extensions.cs
@@ -7,15 +7,15 @@ namespace Frends.Zip.ExtractArchive;
 /// </summary>
 static class Extensions
 {
-    internal static string GetNewFilename(string fullPath, string name, CancellationToken cancellationToken)
+    internal static string GetNewFilename(string path, CancellationToken cancellationToken)
     {
-        var index = 0;
+        var index = 1;
         string newPath;
         do
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var new_Filename = $"{Path.GetFileNameWithoutExtension(name)}({index}){Path.GetExtension(name)}";
-            newPath = Path.Combine(Path.GetDirectoryName(fullPath), new_Filename);
+            var new_Filename = $"{Path.GetFileNameWithoutExtension(path)}({index}){Path.GetExtension(path)}";
+            newPath = Path.Combine(Path.GetDirectoryName(path), new_Filename);
             index++;
         } while (File.Exists(newPath));
         return newPath;

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
@@ -50,10 +50,9 @@ public class Zip
                         if (File.Exists(Path.Combine(input.DestinationDirectory, z.FileName)))
                         {
                             // Find a filename that does not exist. 
-                            var FullPath = Extensions.GetNewFilename(Path.Combine(input.DestinationDirectory, z.FileName),  cancellationToken);
-                            path = FullPath;
+                            path = Extensions.GetNewFilename(Path.Combine(input.DestinationDirectory, z.FileName), cancellationToken);
 
-                            using var fs = new FileStream(FullPath, FileMode.Create, FileAccess.Write);
+                            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
                             z.Extract(fs);
                         }
                         else
@@ -65,7 +64,7 @@ public class Zip
             }
         }
 
-        if (options.DeletetZipFileAfterExtract)
+        if (options.DeleteZipFileAfterExtract)
             File.Delete(input.SourceFile);
 
         return output;

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Ionic.Zip;
 using System.Threading;
 using System.ComponentModel;
@@ -65,7 +66,17 @@ public class Zip
         }
 
         if (options.DeleteZipFileAfterExtract)
-            File.Delete(input.SourceFile);
+        {
+            try
+            {
+                File.Delete(input.SourceFile);
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException($"Extraction was completed but an exception was thrown when trying to delete the source file: {ex.Message}");
+            }
+        }
+            
 
         return output;
     }

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
@@ -50,16 +50,24 @@ public class Zip
                         if (File.Exists(Path.Combine(input.DestinationDirectory, z.FileName)))
                         {
                             // Find a filename that does not exist. 
-                            var FullPath = Extensions.GetNewFilename(Path.Combine(Path.GetDirectoryName(input.DestinationDirectory), z.FileName), z.FileName, cancellationToken);
+                            var FullPath = Extensions.GetNewFilename(Path.Combine(input.DestinationDirectory, z.FileName),  cancellationToken);
                             path = FullPath;
 
-                            using var fs = new FileStream(FullPath, FileMode.Create, FileAccess.Write); z.Extract(fs);
+                            using var fs = new FileStream(FullPath, FileMode.Create, FileAccess.Write);
+                            z.Extract(fs);
                         }
-                        else z.Extract(input.DestinationDirectory);
+                        else
+                        {
+                            z.Extract(input.DestinationDirectory);
+                        }
                     }
                     break;
             }
         }
+
+        if (options.DeletetZipFileAfterExtract)
+            File.Delete(input.SourceFile);
+
         return output;
     }
 

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/ExtractArchive.cs
@@ -76,7 +76,6 @@ public class Zip
                 throw new ArgumentException($"Extraction was completed but an exception was thrown when trying to delete the source file: {ex.Message}");
             }
         }
-            
 
         return output;
     }

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.0.3</Version>
+    <Version>1.1.0</Version>
 		<Description>Task for extracting ZIP archives.</Description>
 		<PackageProjectUrl>https://frends.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FrendsPlatform/Frends.Zip/Frends.Zip.ExtractArchive</RepositoryUrl>


### PR DESCRIPTION
#21 

## [1.1.0] - 2024-10-22
### Fixed
- Fixed issue with rename option writing the extracted files to wrong directory.
### Added
- Added DeletetZipFileAfterExtract option to enable the deletion of the source file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Frends.Zip.ExtractArchive v1.1.0

- **New Features**
  - Introduced the option to delete the source ZIP file after extraction (`DeleteZipFileAfterExtract`).
  
- **Bug Fixes**
  - Resolved an issue where the rename option directed extracted files to the wrong directory.

- **Improvements**
  - Streamlined the extraction process and enhanced error handling for existing files.

- **Project Updates**
  - Updated version number to 1.1.0 and added project URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->