### PR TITLE
change used zip lib

### DIFF
--- a/Frends.Zip.CreateArchive/CHANGELOG.md
+++ b/Frends.Zip.CreateArchive/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [1.1.1] - 2024-12-13
+## [1.2.0] - 2024-12-13
 ### Changed
 - Drop DotNetZip in favour of ProDotNetZip because of security reasons
+- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is depracated)
+- The migration to ProDotNetZip 1.20.0 addresses this security concern
 
 ## [1.1.0] - 2023-11-27
 ### Added

--- a/Frends.Zip.CreateArchive/CHANGELOG.md
+++ b/Frends.Zip.CreateArchive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2024-12-13
+### Changed
+- Drop DotNetZip in favour of ProDotNetZip because of security reasons
+
 ## [1.1.0] - 2023-11-27
 ### Added
 - [Breaking] Added Encoding for file and directory names.

--- a/Frends.Zip.CreateArchive/CHANGELOG.md
+++ b/Frends.Zip.CreateArchive/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.2.0] - 2024-12-13
 ### Changed
 - Drop DotNetZip in favour of ProDotNetZip because of security reasons
-- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is depracated)
+- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is deprecated)
 - The migration to ProDotNetZip 1.20.0 addresses this security concern
 
 ## [1.1.0] - 2023-11-27

--- a/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive.csproj
+++ b/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive.csproj
@@ -8,10 +8,9 @@
 		<Product>Frends</Product>
 		<PackageTags>frends zip archive</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl></PackageProjectUrl>
 		<IncludeSource>true</IncludeSource>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<Version>1.1.1</Version>
+		<Version>1.2.0</Version>
 		<Description>Task for creating ZIP archives.</Description>
 		<PackageProjectUrl>https://frends.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FrendsPlatform/Frends.Zip/Frends.Zip</RepositoryUrl>

--- a/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive.csproj
+++ b/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive/Frends.Zip.CreateArchive.csproj
@@ -11,7 +11,7 @@
 		<PackageProjectUrl></PackageProjectUrl>
 		<IncludeSource>true</IncludeSource>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Description>Task for creating ZIP archives.</Description>
 		<PackageProjectUrl>https://frends.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FrendsPlatform/Frends.Zip/Frends.Zip</RepositoryUrl>
@@ -24,7 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DotNetZip" Version="1.16.0" />
+		<PackageReference Include="ProDotNetZip" Version="1.20.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 	</ItemGroup>
 

--- a/Frends.Zip.ExtractArchive/CHANGELOG.md
+++ b/Frends.Zip.ExtractArchive/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2024-12-13
+### Changed
+- Drop DotNetZip in favour of ProDotNetZip because of security reasons
+
 ## [1.1.0] - 2024-10-22
 ### Fixed
 - Fixed issue with rename option writing the extracted files to wrong directory.

--- a/Frends.Zip.ExtractArchive/CHANGELOG.md
+++ b/Frends.Zip.ExtractArchive/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.2.0] - 2024-12-13
 ### Changed
 - Drop DotNetZip in favour of ProDotNetZip because of security reasons
-- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is depracated)
+- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is deprecated)
 - The migration to ProDotNetZip 1.20.0 addresses this security concern
 
 ## [1.1.0] - 2024-10-22

--- a/Frends.Zip.ExtractArchive/CHANGELOG.md
+++ b/Frends.Zip.ExtractArchive/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [1.1.1] - 2024-12-13
+## [1.2.0] - 2024-12-13
 ### Changed
 - Drop DotNetZip in favour of ProDotNetZip because of security reasons
+- DotNetZip has a HIGH severity directory traversal vulnerability (CVE reported Nov 2024) affecting versions 1.10.1 through 1.16.0 with no patch available (package is depracated)
+- The migration to ProDotNetZip 1.20.0 addresses this security concern
 
 ## [1.1.0] - 2024-10-22
 ### Fixed

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
@@ -8,10 +8,9 @@
 		<Product>Frends</Product>
 		<PackageTags>frends zip archive</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl></PackageProjectUrl>
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
 		<Description>Task for extracting ZIP archives.</Description>
 		<PackageProjectUrl>https://frends.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FrendsPlatform/Frends.Zip/Frends.Zip.ExtractArchive</RepositoryUrl>

--- a/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
+++ b/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive/Frends.Zip.ExtractArchive.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl></PackageProjectUrl>
     <IncludeSource>true</IncludeSource>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
 		<Description>Task for extracting ZIP archives.</Description>
 		<PackageProjectUrl>https://frends.com/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/FrendsPlatform/Frends.Zip/Frends.Zip.ExtractArchive</RepositoryUrl>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="ProDotNetZip" Version="1.20.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated changelogs for `Frends.Zip.CreateArchive` and `Frends.Zip.ExtractArchive` to version 1.2.0.
	- Enhanced zip creation and extraction functionality with the new library ProDotNetZip.
	- Added a project URL for both `Frends.Zip.CreateArchive` and `Frends.Zip.ExtractArchive`.

- **Bug Fixes**
	- Resolved issues related to file extraction paths in the previous version.

- **Chores**
	- Updated the underlying library from DotNetZip to ProDotNetZip for both projects due to security concerns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->